### PR TITLE
Fix for making delay between readings

### DIFF
--- a/HC-SR04-RangeFinder/HC-SR04-RangeFinder.ino
+++ b/HC-SR04-RangeFinder/HC-SR04-RangeFinder.ino
@@ -106,10 +106,9 @@ void loop()
         val = median(srtValues, ARRAY_SIZE);      // find the median value and use it
         break;
       default:
-        break;
-        lastT = nowT;
+        break;    
     }
-
+    lastT = nowT;
 
     if (Serial.available() > 0) {
       // read the incoming byte:


### PR DESCRIPTION
`lastT= nowT;` was never executed.
This resulted in calling `sonar.ping();` without any delay. It was unstable with US-015 sonar module. (HC-SR04 was also unstable)